### PR TITLE
Updated _create_entry to use sqlite's parameter syntax for values

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ table name `student` and rows `student_id`, `student_name` with datatypes
 integer and text, respectively. The default value for `student_name` is
 `John Smith`.
 
-##Basic Usage
+## Basic Usage
 
 ### Entry manipulation
 

--- a/datalite/datalite_decorator.py
+++ b/datalite/datalite_decorator.py
@@ -27,7 +27,8 @@ def _create_entry(self) -> None:
         try:
             cur.execute(f"INSERT INTO {table_name}("
                         f"{', '.join(item[0] for item in kv_pairs)})"
-                        f" VALUES ({', '.join(_convert_sql_format(item[1]) for item in kv_pairs)});")
+                        f" VALUES ({', '.join('?' for item in kv_pairs)})",
+                        [_convert_sql_format(item[1]) for item in kv_pairs])
             self.__setattr__("obj_id", cur.lastrowid)
             con.commit()
         except IntegrityError:


### PR DESCRIPTION
This PR is a partial fix to #6

(It also includes a minor typo fix for the readme)

I have tested this PR in the context of my own data projects. Without it, I cannot ingest my data (it contains JSON strings, among other things, which are incompatible with the string interpolation approach). This PR is able to ingest that same data.

I don't know if it passes any other tests.