### PR TITLE
Fix string encoding on create; adopt query parameters for update

### DIFF
--- a/datalite/datalite_decorator.py
+++ b/datalite/datalite_decorator.py
@@ -28,7 +28,7 @@ def _create_entry(self) -> None:
             cur.execute(f"INSERT INTO {table_name}("
                         f"{', '.join(item[0] for item in kv_pairs)})"
                         f" VALUES ({', '.join('?' for item in kv_pairs)})",
-                        [_convert_sql_format(item[1]) for item in kv_pairs])
+                        [item[1] for item in kv_pairs])
             self.__setattr__("obj_id", cur.lastrowid)
             con.commit()
         except IntegrityError:
@@ -47,9 +47,9 @@ def _update_entry(self) -> None:
         kv_pairs = [item for item in asdict(self).items()]
         kv_pairs.sort(key=lambda item: item[0])
         query = f"UPDATE {table_name} " + \
-                f"SET {', '.join(item[0] + ' = ' + _convert_sql_format(item[1]) for item in kv_pairs)} " + \
+                f"SET {', '.join(item[0] + ' = ?' for item in kv_pairs)} " + \
                 f"WHERE obj_id = {getattr(self, 'obj_id')};"
-        cur.execute(query)
+        cur.execute(query, [item[1] for item in kv_pairs])
         con.commit()
 
 

--- a/test/main_tests.py
+++ b/test/main_tests.py
@@ -64,9 +64,6 @@ def getValFromDB(obj_id = 1):
         fields.sort()
         repr = dict(zip(fields, cur.fetchall()[0][1:]))
         field_types = {key: value.type for key, value in TestClass.__dataclass_fields__.items()}
-        for key in fields:
-            if field_types[key] == bytes:
-                repr[key] = bytes(repr[key], encoding='utf-8')
         test_object = TestClass(**repr)
     return test_object
 


### PR DESCRIPTION
This is a continuation from PR https://github.com/ambertide/datalite/pull/7 and (hopefully) closes issue https://github.com/ambertide/datalite/issues/6

In this PR, both create and update have been updated to use sqlite query parameters.

This PR also fixes a bug from my previous PR (https://github.com/ambertide/datalite/pull/7). There, I was calling `_convert_sql_format()` on the query parameters. This was a mistake on my part; this function call caused strings to be overly-quoted. Fortunately, the adoption of query parameters eliminates the need to call this function. See [SQLite and Python types](https://docs.python.org/3/library/sqlite3.html#sqlite-and-python-types).

Removing these calls to `_convert_sql_format()` appears fine. As before, I have confirmed that this patch is able to insert complex string data. I have also confirmed that the unit tests pass.

Note that I had to update one of the unit tests: by removing `_convert_sql_format()`, it is no longer necessary to manually decode bytes data. See https://github.com/ambertide/datalite/blob/01348bf8cc6760b5e0c92a2dea285ed321c1176c/test/main_tests.py#L69

Unfortunately, `_convert_sql_format()` remains in use when creating tables. I could not remove this call because sqlite does not support query parameters for create table.