### PR TITLE
feat: add support for bool type

### DIFF
--- a/datalite/commons.py
+++ b/datalite/commons.py
@@ -5,7 +5,7 @@ import sqlite3 as sql
 
 
 type_table: Dict[Optional[type], str] = {None: "NULL", int: "INTEGER", float: "REAL",
-                                         str: "TEXT", bytes: "BLOB"}
+                                         str: "TEXT", bytes: "BLOB", bool: "INTEGER"}
 type_table.update({Unique[key]: f"{value} NOT NULL UNIQUE" for key, value in type_table.items()})
 
 
@@ -42,6 +42,8 @@ def _convert_sql_format(value: Any) -> str:
         return f'"{value}"'
     elif isinstance(value, bytes):
         return '"' + str(value).replace("b'", "")[:-1] + '"'
+    elif isinstance(value, bool):
+        return "TRUE" if value else "FALSE"
     else:
         return str(value)
 

--- a/test/main_tests.py
+++ b/test/main_tests.py
@@ -16,6 +16,7 @@ class TestClass:
     byte_value: bytes = b'a'
     float_value: float = 0.4
     str_value: str = 'a'
+    bool_value: bool = True
 
     def __eq__(self, other):
         return asdict(self) == asdict(other)


### PR DESCRIPTION
Add support for bool-typed fields in DataLite dataclasses.

Example:

```
@datalite(db_path='test.db')
@dataclass
class TestClass:
    bool_value: bool = True
```